### PR TITLE
Aggiunto il metodo compact_tokens alla classe nlp

### DIFF
--- a/src/offline/content_analyzer/nlp.py
+++ b/src/offline/content_analyzer/nlp.py
@@ -168,6 +168,23 @@ class NLTK(NLP):
             text = text.replace(url, "<URL>")
         return text
 
+    """
+    This method is useful because the tokenization operation separates the tokens that start with the '<'
+    symbol. For example, the '<URL>' token is seen as three different tokens. This method brings together
+    this kind of tokens, treating them as a unique one.
+    """
+    @staticmethod
+    def __compact_tokens(text: list):
+        for i in range(0, len(text)):
+            if i < len(text) and text[i] == '<':
+                j = i + 1
+                while text[j] != '>':
+                    text[i] = text[i] + text[j]
+                    del text[j]
+                text[i] = text[i] + text[j]
+                del text[j]
+        return text
+
     def process(self, field_data):
         if self.get_strip_multiple_whitespaces():
             field_data = self.__strip_multiple_whitespaces_operation(field_data)
@@ -183,4 +200,4 @@ class NLTK(NLP):
             field_data = self.__stemming_operation(field_data)
         if self.get_named_entity_recognition():
             field_data = self.__named_entity_recognition_operation(field_data)
-        return field_data
+        return self.__compact_tokens(field_data)

--- a/test/offline/content_analyzer/test_nlp.py
+++ b/test/offline/content_analyzer/test_nlp.py
@@ -31,28 +31,28 @@ class TestNLTK(TestCase):
         nltka.set_lemmatization(True)
         self.assertEqual(nltka.process(
                 "The striped bats are hanging on their feet for best"),
-                "The strip bat be hang on their foot for best")
+                ["The", "strip", "bat", "be", "hang", "on", "their", "foot", "for", "best"])
 
         #Test for lemmatization with multiple whitespaces removal
         nltka.set_strip_multiple_whitespaces(True)
         self.assertEqual(nltka.process(
                 "The   striped  bats    are    hanging   on   their    feet   for  best"),
-                "The strip bat be hang on their foot for best")
+                ["The", "strip", "bat", "be", "hang", "on", "their", "foot", "for", "best"])
 
         #Test for lemmatization with multiple whitespaces removal and URL tagging
         nltka.set_url_tagging(True)
         self.assertEqual(nltka.process(
                 "The   striped http://facebook.com bats https://github.com   are   http://facebook.com hanging   on   their    feet   for  best  http://twitter.it"),
-                "The strip <URL> bat <URL> be <URL> hang on their foot for best <URL>")
+                ["The", "strip", "<URL>", "bat", "<URL>", "be", "<URL>", "hang", "on", "their", "foot", "for", "best", "<URL>"])
 
         # Test for lemmatization, multiple whitespaces removal, URL tagging and stemming
         nltka.set_stemming(True)
         self.assertEqual(nltka.process(
             "The   striped http://facebook.com bats https://github.com   are   http://facebook.com hanging   on   their    feet   for  best  http://twitter.it"),
-            "the strip <url> bat <url> be <url> hang on their foot for best <url>")
+            ["the", "strip", "<url>", "bat", "<url>", "be", "<url>", "hang", "on", "their", "foot", "for", "best", "<url>"])
 
         # Test for lemmatization, multiple whitespaces removal, URL tagging, stemming, stop words removal
         nltka.set_stopwords_removal(True)
         self.assertEqual(nltka.process(
             "The   striped http://facebook.com bats https://github.com   are   http://facebook.com hanging   on   their    feet   for  best  http://twitter.it"),
-            "the strip < url > bat < url > < url > hang foot best < url >")
+            ["the", "strip", "<url>", "bat", "<url>", "<url>", "hang", "foot", "best", "<url>"])


### PR DESCRIPTION
Nel file nlp.py ho aggiunto un metodo che viene applicato sempre alla fine del process e risolve quel problema che vi dissi relativo alla tokenizzazione degli url. Prima infatti, la parola "<URL>" veniva tokenizzata così: "<", "URL", ">". Il metodo che ho aggiunto unisce i tre token in un token unico