### PR TITLE
Fase di preparazione del dataset per tecniche che la richiedono

### DIFF
--- a/src/offline/config.json
+++ b/src/offline/config.json
@@ -32,7 +32,7 @@
           ]
         },
         {
-        "field_content_production": {"class": "tf-idf"},
+        "field_content_production": {"class": "lucene_tf-idf"},
         "preprocessing_list": [
           {"class": "nltk", "stopwords_removal":"True", "lemmatization":"True"}
           ]

--- a/src/offline/content_analyzer/content_analyzer_main.py
+++ b/src/offline/content_analyzer/content_analyzer_main.py
@@ -272,11 +272,3 @@ class ContentsProducer:
                 content.append(field)
 
             return content
-
-
-# cambiata struttura classe tecnica, suddivisione in tecniche basate su collezione e tecniche basate su singolo item
-# aggiunto metodo dataset refactor alle tecniche basate su collezione
-# aggiunto un id progressivo alla classe pipeline, da usare come nome del field da memorizzare nella nuova struttura (index per tf-idf ad esempio)
-# chiamato il metodo dataset_refactor per le coppie (field_name, pipeline) associate,
-# nella configurazione, a una tecnica che necessita di tale processo
-# alcuni commenti

--- a/src/offline/content_analyzer/content_analyzer_main.py
+++ b/src/offline/content_analyzer/content_analyzer_main.py
@@ -172,14 +172,14 @@ class ContentAnalyzer:
             for pipeline in self.__config.get_pipeline_list(field_name):
                 if isinstance(pipeline.get_content_technique(), CollectionBasedTechnique):
                     pipeline.get_content_technique().\
-                        append_field_need_refactor(field_name + str(pipeline), pipeline.get_preprocessor_list())
+                        append_field_need_refactor(field_name, str(pipeline), pipeline.get_preprocessor_list())
 
         for technique in self.__config.get_collection_based_techniques():
             technique.dataset_refactor(self.__config.get_source(), self.__config.get_id_field_name())
 
         i = 0
         for raw_content in self.__config.get_source():
-            print(contents_producer.create_content(raw_content, need_dataset_refactor))
+            print(contents_producer.create_content(raw_content))
             i += 1
 
         return contents

--- a/src/offline/content_analyzer/entity_linking.py
+++ b/src/offline/content_analyzer/entity_linking.py
@@ -1,5 +1,3 @@
-from babelpy.config.config import LANG, API_KEY
-
 from src.offline.content_analyzer.content_representation.content_field import FeaturesBagField
 from src.offline.content_analyzer.field_content_production_technique import EntityLinking
 from babelpy.babelfy import BabelfyClient

--- a/src/offline/content_analyzer/entity_linking.py
+++ b/src/offline/content_analyzer/entity_linking.py
@@ -14,8 +14,8 @@ class BabelPyEntityLinking(EntityLinking):
         params['lang'] = lang
         self.__babel_client = BabelfyClient(api_key, params)
 
-    def produce_content(self, field_representation_name: str, **kwargs) -> FeaturesBagField:
-        self.__babel_client.babelfy(kwargs["field_data"])
+    def produce_content(self, field_representation_name: str, field_data: str) -> FeaturesBagField:
+        self.__babel_client.babelfy(field_data)
         feature_bag = FeaturesBagField('repr_field_name')
         if self.__babel_client.entities is not None:
             for entity in self.__babel_client.entities:

--- a/src/offline/content_analyzer/field_content_production_technique.py
+++ b/src/offline/content_analyzer/field_content_production_technique.py
@@ -9,7 +9,6 @@ from src.offline.memory_interfaces.text_interface import IndexInterface
 from src.offline.content_analyzer.content_representation.content_field \
     import EmbeddingField, FeaturesBagField, FieldRepresentation, GraphField
 from src.offline.raw_data_extractor.raw_information_source import RawInformationSource
-from src.offline.utils.id_merger import id_merger
 
 
 class FieldContentProductionTechnique(ABC):
@@ -80,32 +79,14 @@ class TfIdfTechnique(CollectionBasedTechnique):
         super().__init__()
         self.__index = IndexInterface('./frequency-index')
 
+    @abstractmethod
     def produce_content(self, field_representation_name: str, content_id: str,
                         field_name: str, pipeline_id: str) -> FeaturesBagField:
-        return FeaturesBagField(field_representation_name, self.__index.get_tf_idf(field_name + pipeline_id, content_id))
+        pass
 
+    @abstractmethod
     def dataset_refactor(self, information_source: RawInformationSource, id_field_names: str):
-        if len(self.get_need_refactor().keys()) != 0:
-            self.__index = IndexInterface('./frequency-index')
-            self.__index.init_writing()
-            for raw_content in information_source:
-                self.__index.new_content()
-                id_values = []
-
-                for name in id_field_names:
-                    id_values.append(raw_content[name])
-
-                self.__index.new_field("content_id", id_merger(id_values))
-
-                for (field_name, pipeline_id) in self.get_need_refactor().keys():
-                    preprocessor_list = self.get_need_refactor()[(field_name, pipeline_id)]
-                    processed_field_data = raw_content[field_name]
-                    for preprocessor in preprocessor_list:
-                        processed_field_data = preprocessor.process(processed_field_data)
-                    self.__index.new_field(field_name + pipeline_id, processed_field_data)
-                self.__index.serialize_content()
-
-            self.__index.stop_writing()
+        pass
 
 
 class EntityLinking(SingleContentTechnique):

--- a/src/offline/content_analyzer/field_content_production_technique.py
+++ b/src/offline/content_analyzer/field_content_production_technique.py
@@ -1,12 +1,15 @@
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import List
+from typing import List, Tuple, Dict
 
 import numpy as np
 
+from src.offline.content_analyzer.information_processor import InformationProcessor
 from src.offline.memory_interfaces.text_interface import IndexInterface
 from src.offline.content_analyzer.content_representation.content_field \
     import EmbeddingField, FeaturesBagField, FieldRepresentation, GraphField
+from src.offline.raw_data_extractor.raw_information_source import RawInformationSource
+from src.offline.utils.id_merger import id_merger
 
 
 class FieldContentProductionTechnique(ABC):
@@ -18,10 +21,33 @@ class FieldContentProductionTechnique(ABC):
     def __init__(self):
         pass
 
+
+class CollectionBasedTechnique(FieldContentProductionTechnique):
+    def __init__(self):
+        super().__init__()
+        self.__need_refactor: Dict[Tuple[str, str], List[InformationProcessor]] = {}
+
+    def append_field_need_refactor(self, field_name: str, pipeline_id, processor_list: List[InformationProcessor]):
+        self.__need_refactor[(field_name, pipeline_id)] = processor_list
+
+    def get_need_refactor(self):
+        return self.__need_refactor
+
     @abstractmethod
-    def produce_content(self, field_representation_name: str, **kwargs) -> FieldRepresentation:
+    def produce_content(self, field_representation_name: str, content_id: str,
+                        field_name: str, pipeline_id: str) -> FieldRepresentation:
+        pass
+
+    @abstractmethod
+    def dataset_refactor(self, information_source: RawInformationSource, id_field_names):
+        pass
+
+
+class SingleContentTechnique(FieldContentProductionTechnique):
+    @abstractmethod
+    def produce_content(self, field_representation_name: str, field_data: str) -> FieldRepresentation:
         """
-        Given data of certain field it returns a copmlex representation's instance of the field.
+        Given data of certain field it returns a complex representation's instance of the field.
         Args:
             field_representation_name: name of the field representation object that will be created
             field_data: input for the complex representation production
@@ -32,7 +58,7 @@ class FieldContentProductionTechnique(ABC):
         """
 
 
-class FieldToGraph(FieldContentProductionTechnique):
+class FieldToGraph(SingleContentTechnique):
     """
     Abstract class that generalize techniques
     that uses ontologies or LOD for producing the semantic description
@@ -43,7 +69,7 @@ class FieldToGraph(FieldContentProductionTechnique):
         pass
 
 
-class TfIdfTechnique(FieldContentProductionTechnique):
+class TfIdfTechnique(CollectionBasedTechnique):
     """
     Class that produce a Bag of words with tf-idf metric
     Args:
@@ -52,14 +78,36 @@ class TfIdfTechnique(FieldContentProductionTechnique):
 
     def __init__(self):
         super().__init__()
-        self.__memory_interface = IndexInterface('./frequency-index')
+        self.__index = IndexInterface('./frequency-index')
 
     def produce_content(self, field_representation_name: str, **kwargs) -> FeaturesBagField:
-        return FeaturesBagField(field_representation_name, self.__memory_interface.get_tf_idf(kwargs["field_name"], kwargs["item_id"])
-)
+        return FeaturesBagField(field_representation_name, self.__index.get_tf_idf(kwargs["field_name"], kwargs["item_id"]))
+
+    def dataset_refactor(self, information_source: RawInformationSource, id_field_names: str):
+        if len(self.get_need_refactor().keys()) != 0:
+            self.__index = IndexInterface('./frequency-index')
+            self.__index.init_writing()
+            for raw_content in information_source:
+                self.__index.new_content()
+                id_values = []
+
+                for name in id_field_names:
+                    id_values.append(raw_content[name])
+
+                self.__index.new_field("content_id", id_merger(id_values))
+
+                for field_pipeline_name in self.get_need_refactor().keys():
+                    preprocessor_list = self.get_need_refactor()[field_pipeline_name]
+                    processed_field_data = raw_content[field_pipeline_name]
+                    for preprocessor in preprocessor_list:
+                        processed_field_data = preprocessor.process(processed_field_data)
+                    self.__index.new_field(field_pipeline_name, processed_field_data)
+                self.__index.serialize_content()
+
+            self.__index.stop_writing()
 
 
-class EntityLinking(FieldContentProductionTechnique):
+class EntityLinking(SingleContentTechnique):
     """
     Abstract class that generalize implementations
     that uses entity linking for producing the semantic description
@@ -168,7 +216,7 @@ class SentenceDetectionTechnique(ABC):
         pass
 
 
-class EmbeddingTechnique(FieldContentProductionTechnique):
+class EmbeddingTechnique(SingleContentTechnique):
     """
     Class that can be used to combine different embeddings coming to various sources
     in order to produce the semantic description.

--- a/src/offline/content_analyzer/tf_idf.py
+++ b/src/offline/content_analyzer/tf_idf.py
@@ -1,0 +1,44 @@
+from src.offline.content_analyzer.content_representation.content_field import FeaturesBagField
+from src.offline.content_analyzer.field_content_production_technique import TfIdfTechnique
+from src.offline.memory_interfaces.text_interface import IndexInterface
+from src.offline.raw_data_extractor.raw_information_source import RawInformationSource
+from src.offline.utils.id_merger import id_merger
+
+
+class LuceneTfIdf(TfIdfTechnique):
+    """
+    Class that produce a Bag of words with tf-idf metric
+    Args:
+
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.__index = IndexInterface('./frequency-index')
+
+    def produce_content(self, field_representation_name: str, content_id: str,
+                        field_name: str, pipeline_id: str) -> FeaturesBagField:
+        return FeaturesBagField(field_representation_name, self.__index.get_tf_idf(field_name + pipeline_id, content_id))
+
+    def dataset_refactor(self, information_source: RawInformationSource, id_field_names: str):
+        if len(self.get_need_refactor().keys()) != 0:
+            self.__index = IndexInterface('./frequency-index')
+            self.__index.init_writing()
+            for raw_content in information_source:
+                self.__index.new_content()
+                id_values = []
+
+                for name in id_field_names:
+                    id_values.append(raw_content[name])
+
+                self.__index.new_field("content_id", id_merger(id_values))
+
+                for (field_name, pipeline_id) in self.get_need_refactor().keys():
+                    preprocessor_list = self.get_need_refactor()[(field_name, pipeline_id)]
+                    processed_field_data = raw_content[field_name]
+                    for preprocessor in preprocessor_list:
+                        processed_field_data = preprocessor.process(processed_field_data)
+                    self.__index.new_field(field_name + pipeline_id, processed_field_data)
+                self.__index.serialize_content()
+
+            self.__index.stop_writing()

--- a/src/offline/run.py
+++ b/src/offline/run.py
@@ -93,7 +93,8 @@ def config_run(config_list: List[Dict]):
                 config_dict[field_dict['field_name']] = runnable_instances[field_dict['memory_interface']](
                     field_dict['memory_interface_path'])
 
-        # setting the phase 1 configuration
+        # setting the phase 1 configurati\
+        # on
         raw_data_config = RawDataConfig(
             runnable_instances[content_config['source_type']](content_config['raw_source_path']),
             content_config['id_field_name'], config_dict)

--- a/src/offline/run.py
+++ b/src/offline/run.py
@@ -8,11 +8,12 @@ from src.offline.content_analyzer.embedding_source import GensimDownloader, Bina
 from src.offline.content_analyzer.content_analyzer_main import ContentAnalyzer, FieldConfig, ContentAnalyzerConfig, \
     FieldRepresentationPipeline
 from src.offline.content_analyzer.entity_linking import BabelPyEntityLinking
-from src.offline.content_analyzer.field_content_production_technique import TfIdfTechnique, EmbeddingTechnique
+from src.offline.content_analyzer.field_content_production_technique import EmbeddingTechnique
 from src.offline.content_analyzer.nlp import NLTK
 from src.offline.memory_interfaces.text_interface import IndexInterface
 from src.offline.raw_data_extractor.raw_data_manager import RawDataConfig, RawDataManager
 from src.offline.raw_data_extractor.raw_information_source import JSONFile, CSVFile, SQLDatabase
+from src.offline.content_analyzer.tf_idf import LuceneTfIdf
 
 lucene.initVM(vmargs=['-Djava.awt.headless=true'])
 
@@ -25,7 +26,7 @@ implemented_preprocessing = [
 implemented_content_prod = [
     "embedding",
     "babelpy",
-    "tf-idf",
+    "lucene_tf-idf",
 ]
 
 runnable_instances = {
@@ -35,7 +36,7 @@ runnable_instances = {
     "index": IndexInterface,
     "babelpy": BabelPyEntityLinking,
     "nltk": NLTK,
-    "tf-idf": TfIdfTechnique,
+    "lucene_tf-idf": LuceneTfIdf,
     "binary_file": BinaryFile,
     "gensim_downloader": GensimDownloader,
     "centroid": Centroid,


### PR DESCRIPTION
In questo branch ho:
- modificato la struttura della classe astratta _FieldContentProductionTechnique_, le tecniche sono ora divise in tecniche che **richiedono l'intero dataset**(_CollectionBasedTechnique_; esempio: tf-idf) per produrre un contenuto e tecniche basate sul **singolo contenuto**(_SingleContentTechnique_; esempi: embedding, entity-linking)
- aggiunto metodo _dataset_refactor_ alla classe astratta _CollectionBasedTechnique_, tale metodo ha l'obiettivo di ristrutturare il dataset in un modo funzionale all'ottenimento della rappresentazione(indice lucene per tf-idf che ottimizza il calcolo delle frequenze), il dataset riorganizzato contiene i dati elaborati con le tecniche di preprocessing specificate nel config; tale fase riguarda solo le field_representation che la richiedono 
- aggiunto un id progressivo alla classe pipeline, da concatenare ai rispettivi field_name per ottenere i nomi dei field di cui è costituito il dataset riorganizzato, è necessario un field differente per ogni pipeline poichè i preprocessor possono essere dfiferenti
- invocato il metodo _dataset_refactor_ **da** _content_analyzer_main_ per le pipeline associate a una tecnica che lo richiedono
Closes #22 